### PR TITLE
Mlcube download log

### DIFF
--- a/cli/medperf/account_management/account_management.py
+++ b/cli/medperf/account_management/account_management.py
@@ -7,7 +7,7 @@ from medperf.exceptions import MedperfException
 def read_user_account():
     config_p = read_config()
     if config.credentials_keyword not in config_p.active_profile:
-        raise MedperfException("You are not logged in")
+        return
 
     account_info = config_p.active_profile[config.credentials_keyword]
     return account_info
@@ -35,6 +35,8 @@ def set_credentials(
 
 def read_credentials():
     account_info = read_user_account()
+    if account_info is None:
+        raise MedperfException("You are not logged in")
     email = account_info["email"]
     access_token, refresh_token = TokenStore().read_tokens(email)
 

--- a/cli/medperf/account_management/token_storage/filesystem.py
+++ b/cli/medperf/account_management/token_storage/filesystem.py
@@ -28,14 +28,18 @@ class FilesystemTokenStore:
 
     def set_tokens(self, account_id, access_token, refresh_token):
         access_token_file, refresh_token_file = self.__get_paths(account_id)
-        logging.debug("Writing tokens to disk.")
-        fd = os.open(access_token_file, os.O_CREAT | os.O_WRONLY, 0o600)
-        os.write(fd, access_token.encode("utf-8"))
-        os.close(fd)
 
-        fd = os.open(refresh_token_file, os.O_CREAT | os.O_WRONLY, 0o600)
-        os.write(fd, refresh_token.encode("utf-8"))
-        os.close(fd)
+        with open(access_token_file, "w") as f:
+            pass
+        os.chmod(access_token_file, 0o600)
+        with open(access_token_file, "a") as f:
+            f.write(access_token)
+
+        with open(refresh_token_file, "w") as f:
+            pass
+        os.chmod(refresh_token_file, 0o600)
+        with open(refresh_token_file, "a") as f:
+            f.write(refresh_token)
 
     def read_tokens(self, account_id):
         access_token_file, refresh_token_file = self.__get_paths(account_id)

--- a/cli/medperf/cli.py
+++ b/cli/medperf/cli.py
@@ -17,6 +17,7 @@ import medperf.commands.profile as profile
 import medperf.commands.association.association as association
 import medperf.commands.compatibility_test.compatibility_test as compatibility_test
 import medperf.commands.storage as storage
+from medperf.utils import check_for_updates
 
 app = typer.Typer()
 app.add_typer(mlcube.app, name="mlcube", help="Manage mlcubes")
@@ -99,5 +100,6 @@ def main(
 
     logging.info(f"Running MedPerf v{__version__} on {loglevel} logging level")
     logging.info(f"Executed command: {' '.join(sys.argv[1:])}")
+    check_for_updates()
 
     config.ui.print(f"MedPerf {__version__}")

--- a/cli/medperf/commands/auth/login.py
+++ b/cli/medperf/commands/auth/login.py
@@ -1,6 +1,16 @@
 import medperf.config as config
-from medperf.exceptions import InvalidArgumentError
+from medperf.account_management import read_user_account
+from medperf.exceptions import InvalidArgumentError, MedperfException
 from email_validator import validate_email, EmailNotValidError
+
+
+def raise_if_logged_in():
+    account_info = read_user_account()
+    if account_info is not None:
+        raise MedperfException(
+            f"You are already logged in as {account_info['email']}."
+            " Logout before logging in again"
+        )
 
 
 class Login:
@@ -8,6 +18,7 @@ class Login:
     def run(email: str = None):
         """Authenticate to be able to access the MedPerf server. A verification link will
         be provided and should be open in a browser to complete the login process."""
+        raise_if_logged_in()
         if not email:
             email = config.ui.prompt("Please type your email: ")
         try:

--- a/cli/medperf/commands/auth/status.py
+++ b/cli/medperf/commands/auth/status.py
@@ -1,17 +1,14 @@
 import medperf.config as config
 from medperf.account_management import read_user_account
-from medperf.exceptions import MedperfException
 
 
 class Status:
     @staticmethod
     def run():
         """Shows the currently logged in user."""
-        try:
-            account_info = read_user_account()
-        except MedperfException as e:
-            # TODO: create a specific exception about unauthenticated client
-            config.ui.print(str(e))
+        account_info = read_user_account()
+        if account_info is None:
+            config.ui.print("You are not logged in")
             return
 
         email = account_info["email"]

--- a/cli/medperf/commands/execution.py
+++ b/cli/medperf/commands/execution.py
@@ -90,7 +90,7 @@ class Execution:
         except ExecutionError as e:
             if not self.ignore_model_errors:
                 logging.error(f"Model MLCube Execution failed: {e}")
-                raise ExecutionError("Model MLCube failed")
+                raise ExecutionError(f"Model MLCube failed: {e}")
             else:
                 self.partial = True
                 logging.warning(f"Model MLCube Execution failed: {e}")

--- a/cli/medperf/entities/cube.py
+++ b/cli/medperf/entities/cube.py
@@ -250,8 +250,7 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
         logging.info(f"Running MLCube command: {cmd}")
         with spawn_and_kill(cmd, timeout=config.mlcube_inspect_timeout) as proc_wrapper:
             proc = proc_wrapper.proc
-            proc_stdout = proc.read()
-        logging.debug(proc_stdout)
+            combine_proc_sp_text(proc)
         if proc.exitstatus != 0:
             raise ExecutionError("There was an error while inspecting the image hash")
         with open(tmp_out_yaml) as f:
@@ -270,10 +269,9 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
         logging.info(f"Running MLCube command: {cmd}")
         with spawn_and_kill(cmd, timeout=config.mlcube_configure_timeout) as proc_wrapper:
             proc = proc_wrapper.proc
-            proc_out = proc.read()
+            combine_proc_sp_text(proc)
         if proc.exitstatus != 0:
             raise ExecutionError("There was an error while retrieving the MLCube image")
-        logging.debug(proc_out)
 
     def download_config_files(self):
         try:
@@ -369,9 +367,7 @@ class Cube(Entity, Uploadable, MedperfSchema, DeployableSchema):
             proc = proc_wrapper.proc
             proc_out = combine_proc_sp_text(proc)
 
-        if output_logs is None:
-            logging.debug(proc_out)
-        else:
+        if output_logs is not None:
             with open(output_logs, "w") as f:
                 f.write(proc_out)
         if proc.exitstatus != 0:

--- a/cli/medperf/tests/entities/test_cube.py
+++ b/cli/medperf/tests/entities/test_cube.py
@@ -39,8 +39,9 @@ def setup(request, mocker, comms, fs):
 
     # Mock additional third party elements
     mpexpect = MockPexpect(0)
-    mocker.patch(PATCH_CUBE.format("pexpect.spawn"), side_effect=mpexpect.spawn)
+    mocker.patch(PATCH_CUBE.format("spawn_and_kill.spawn"), side_effect=mpexpect.spawn)
     mocker.patch(PATCH_CUBE.format("combine_proc_sp_text"), return_value="")
+    mocker.patch(PATCH_CUBE.format("spawn_and_kill.killpg"), return_value="")
 
     return request.param
 
@@ -95,7 +96,7 @@ class TestGetFiles:
         fs.create_file(
             "tmp_path", contents=yaml.dump({"hash": NO_IMG_CUBE["image_hash"]})
         )
-        spy = mocker.spy(medperf.entities.cube.pexpect, "spawn")
+        spy = mocker.spy(medperf.entities.cube.spawn_and_kill, "spawn")
         expected_cmds = [
             f"mlcube --log-level debug configure --mlcube={self.manifest_path} --platform={config.platform}",
             f"mlcube --log-level debug inspect --mlcube={self.manifest_path}"
@@ -122,7 +123,7 @@ class TestGetFiles:
             "tmp_path", contents=yaml.dump({"hash": NO_IMG_CUBE["image_hash"]})
         )
         mpexpect = MockPexpect(1, "expected_hash")
-        mocker.patch("pexpect.spawn", side_effect=mpexpect.spawn)
+        mocker.patch(PATCH_CUBE.format("spawn_and_kill.spawn"), side_effect=mpexpect.spawn)
 
         # Act & Assert
         cube = Cube.get(self.id)
@@ -147,7 +148,7 @@ class TestGetFiles:
     @pytest.mark.parametrize("setup", [{"remote": [DEFAULT_CUBE]}], indirect=True)
     def test_download_run_files_with_image_isnt_configured(self, mocker, setup):
         # Arrange
-        spy = mocker.spy(medperf.entities.cube.pexpect, "spawn")
+        spy = mocker.spy(medperf.entities.cube.spawn_and_kill, "spawn")
 
         # Act
         cube = Cube.get(self.id)
@@ -175,7 +176,7 @@ class TestRun:
         # Arrange
         mpexpect = MockPexpect(0, "expected_hash")
         spy = mocker.patch(
-            PATCH_CUBE.format("pexpect.spawn"), side_effect=mpexpect.spawn
+            PATCH_CUBE.format("spawn_and_kill.spawn"), side_effect=mpexpect.spawn
         )
         mocker.patch(PATCH_CUBE.format("Cube.get_config"), side_effect=["", ""])
         expected_cmd = (
@@ -196,7 +197,7 @@ class TestRun:
     def test_cube_runs_command_with_rw_access(self, mocker, setup, task):
         # Arrange
         mpexpect = MockPexpect(0, "expected_hash")
-        spy = mocker.patch("pexpect.spawn", side_effect=mpexpect.spawn)
+        spy = mocker.patch(PATCH_CUBE.format("spawn_and_kill.spawn"), side_effect=mpexpect.spawn)
         mocker.patch(
             PATCH_CUBE.format("Cube.get_config"),
             side_effect=["", ""],
@@ -219,7 +220,7 @@ class TestRun:
     def test_cube_runs_command_with_extra_args(self, mocker, setup, task):
         # Arrange
         mpexpect = MockPexpect(0, "expected_hash")
-        spy = mocker.patch("pexpect.spawn", side_effect=mpexpect.spawn)
+        spy = mocker.patch(PATCH_CUBE.format("spawn_and_kill.spawn"), side_effect=mpexpect.spawn)
         mocker.patch(PATCH_CUBE.format("Cube.get_config"), side_effect=["", ""])
         expected_cmd = (
             f"mlcube --log-level debug run --mlcube={self.manifest_path} --task={task} "
@@ -239,7 +240,7 @@ class TestRun:
     def test_cube_runs_command_and_preserves_runtime_args(self, mocker, setup, task):
         # Arrange
         mpexpect = MockPexpect(0, "expected_hash")
-        spy = mocker.patch("pexpect.spawn", side_effect=mpexpect.spawn)
+        spy = mocker.patch(PATCH_CUBE.format("spawn_and_kill.spawn"), side_effect=mpexpect.spawn)
         mocker.patch(
             PATCH_CUBE.format("Cube.get_config"),
             side_effect=["cpuarg cpuval", "gpuarg gpuval"],
@@ -262,7 +263,7 @@ class TestRun:
     def test_run_stops_execution_if_child_fails(self, mocker, setup, task):
         # Arrange
         mpexpect = MockPexpect(1, "expected_hash")
-        mocker.patch("pexpect.spawn", side_effect=mpexpect.spawn)
+        mocker.patch(PATCH_CUBE.format("spawn_and_kill.spawn"), side_effect=mpexpect.spawn)
         mocker.patch(PATCH_CUBE.format("Cube.get_config"), side_effect=["", ""])
 
         # Act & Assert

--- a/cli/medperf/tests/mocks/pexpect.py
+++ b/cli/medperf/tests/mocks/pexpect.py
@@ -1,7 +1,8 @@
 class MockChild:
-    def __init__(self, exitstatus, stdout):
+    def __init__(self, exitstatus, stdout, pid):
         self.exitstatus = exitstatus
         self.stdout = stdout
+        self.pid = pid
 
     def __enter__(self, *args, **kwargs):
         return self
@@ -18,11 +19,15 @@ class MockChild:
     def close(self):
         pass
 
+    def wait(self):
+        pass
+
 
 class MockPexpect:
-    def __init__(self, exitstatus, stdout=""):
+    def __init__(self, exitstatus, stdout="", pid=123456):
         self.exitstatus = exitstatus
         self.stdout = stdout
+        self.pid = pid
 
     def spawn(self, command: str, timeout: int = 30) -> MockChild:
-        return MockChild(self.exitstatus, self.stdout)
+        return MockChild(self.exitstatus, self.stdout, self.pid)

--- a/cli/medperf/tests/ui/test_cli.py
+++ b/cli/medperf/tests/ui/test_cli.py
@@ -21,7 +21,18 @@ class TestDisplayingMessages:
         cli.print(msg)
 
         # Assert
-        spy.assert_called_once_with(msg)
+        spy.assert_called_once_with(msg, nl=True)
+
+    @pytest.mark.parametrize("nl", [True, False])
+    def test_print_typer_new_line(self, mocker, cli, msg, nl):
+        # Arrange
+        spy = mocker.patch("typer.echo")
+
+        # Act
+        cli.print(msg, nl=nl)
+
+        # Assert
+        spy.assert_called_once_with(msg, nl=nl)
 
     def test_print_displays_message_through_yaspin_when_interactive(
         self, mocker, cli, msg

--- a/cli/medperf/ui/cli.py
+++ b/cli/medperf/ui/cli.py
@@ -11,13 +11,14 @@ class CLI(UI):
         self.spinner = yaspin(color="green")
         self.is_interactive = False
 
-    def print(self, msg: str = ""):
+    def print(self, msg: str = "", nl: bool = True):
         """Display a message on the command line
 
         Args:
             msg (str): message to print
+            nl: if print a new line after message
         """
-        self.__print(msg)
+        self.__print(msg, nl=nl)
 
     def print_error(self, msg: str):
         """Display an error message on the command line
@@ -38,11 +39,14 @@ class CLI(UI):
         msg = typer.style(msg, fg=typer.colors.YELLOW, bold=True)
         self.__print(msg)
 
-    def __print(self, msg: str = ""):
+    def __print(self, msg: str = "", nl: bool = True):
         if self.is_interactive:
+            # TODO: nl does not work for yaspin as new-line character
+            #  is explicitly hardcoded in spinner.write()
             self.spinner.write(msg)
         else:
-            typer.echo(msg)
+            # pass
+            typer.echo(msg, nl=nl)
 
     def start_interactive(self):
         """Start an interactive session where messages can be overwritten

--- a/cli/medperf/ui/interface.py
+++ b/cli/medperf/ui/interface.py
@@ -1,10 +1,12 @@
-from abc import ABC, abstractmethod
+from abc import ABC, abstractmethod, abstractproperty
 from contextlib import contextmanager
 
 
 class UI(ABC):
+    is_interactive: bool = False
+
     @abstractmethod
-    def print(self, msg: str = ""):
+    def print(self, msg: str = "", nl: bool = True):
         """Display a message to the interface. If on interactive session overrides
         previous message
         """
@@ -33,19 +35,17 @@ class UI(ABC):
     def interactive(self):
         """Context managed interactive session. Expected to yield the same instance"""
 
+    @property
     @abstractmethod
-    def text(self, msg: str):
+    def text(self):
         """Displays a messages that overwrites previous messages if they were created
         during an interactive session.
         If not supported or not on an interactive session, it is expected to fallback
         to the UI print function.
-
-        Args:
-            msg (str): message to display
         """
 
     @abstractmethod
-    def prompt(msg: str) -> str:
+    def prompt(self, msg: str) -> str:
         """Displays a prompt to the user and waits for an answer"""
 
     @abstractmethod

--- a/cli/medperf/ui/stdin.py
+++ b/cli/medperf/ui/stdin.py
@@ -11,8 +11,8 @@ class StdIn(UI):
     hidden prompts and interactive prints will not work as expected.
     """
 
-    def print(self, msg: str = ""):
-        return print(msg)
+    def print(self, msg: str = "", nl: bool = True):
+        return print(msg, end='\n' if nl else '')
 
     def print_error(self, msg: str):
         return self.print(msg)
@@ -40,3 +40,6 @@ class StdIn(UI):
 
     def hidden_prompt(self, msg: str) -> str:
         return self.prompt(msg)
+
+    def print_highlight(self, msg: str = ""):
+        self.print(msg)

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -257,7 +257,6 @@ def combine_proc_sp_text(proc: spawn) -> str:
     """
 
     ui = config.ui
-    static_text = ui.text
     proc_out = ""
     break_ = False
     log_filter = _MLCubeOutputFilter(proc.pid)
@@ -269,18 +268,22 @@ def combine_proc_sp_text(proc: spawn) -> str:
             line = proc.readline()
         except TIMEOUT:
             logging.error("Process timed out")
+            logging.debug(proc_out)
             raise ExecutionError("Process timed out")
         line = line.decode("utf-8", "ignore")
 
         if not line:
             continue
 
-        if log_filter.check_line(line):
-            logging.debug(line)
-        else:
-            proc_out += line
+        # Always log each line just in case the final proc_out
+        # wasn't logged for some reason
+        logging.debug(line)
+        proc_out += line
+        if not log_filter.check_line(line):
             ui.print(f"{Fore.WHITE}{Style.DIM}{line.strip()}{Style.RESET_ALL}")
-            ui.text = static_text
+
+    logging.debug("MLCube process finished")
+    logging.debug(proc_out)
     return proc_out
 
 

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -19,6 +19,7 @@ from pydantic.datetime_parse import parse_datetime
 from typing import List
 from colorama import Fore, Style
 from pexpect.exceptions import TIMEOUT
+from git import Repo, GitCommandError
 import medperf.config as config
 from medperf.exceptions import ExecutionError, MedperfException, InvalidEntityError
 
@@ -436,6 +437,41 @@ def filter_latest_associations(associations, entity_key):
 
     latest_associations = list(latest_associations.values())
     return latest_associations
+
+
+def check_for_updates() -> None:
+    """Check if the current branch is up-to-date with its remote counterpart using GitPython."""
+    repo = Repo(config.BASE_DIR)
+    if repo.bare:
+        logging.debug('Repo is bare')
+        return
+
+    logging.debug(f'Current git commit: {repo.head.commit.hexsha}')
+
+    try:
+        for remote in repo.remotes:
+            remote.fetch()
+
+        if repo.head.is_detached:
+            logging.debug('Repo is in detached state')
+            return
+
+        current_branch = repo.active_branch
+        tracking_branch = current_branch.tracking_branch()
+
+        if tracking_branch is None:
+            logging.debug("Current branch does not track a remote branch.")
+            return
+        if current_branch.commit.hexsha == tracking_branch.commit.hexsha:
+            logging.debug('No git branch updates.')
+            return
+
+        logging.debug(f'Git branch updates found: {current_branch.commit.hexsha} -> {tracking_branch.commit.hexsha}')
+        config.ui.print_warning('MedPerf client updates found. Please, update your MedPerf installation.')
+    except GitCommandError as e:
+        logging.debug('Exception raised during updates check. Maybe user checked out repo with git@ and private key'
+                      'or repo is in detached / non-tracked state?')
+        logging.debug(e)
 
 
 class spawn_and_kill:

--- a/cli/medperf/utils.py
+++ b/cli/medperf/utils.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import re
 import os
+import signal
 import yaml
 import random
 import hashlib
@@ -435,3 +436,40 @@ def filter_latest_associations(associations, entity_key):
 
     latest_associations = list(latest_associations.values())
     return latest_associations
+
+
+class spawn_and_kill:
+    def __init__(self, cmd, timeout=None, *args, **kwargs):
+        self.cmd = cmd
+        self.timeout = timeout
+        self._args = args
+        self._kwargs = kwargs
+        self.proc: spawn
+        self.exception_occurred = False
+
+    @staticmethod
+    def spawn(*args, **kwargs):
+        return spawn(*args, **kwargs)
+
+    def killpg(self):
+        os.killpg(self.pid, signal.SIGINT)
+
+    def __enter__(self):
+        self.proc = self.spawn(self.cmd, timeout=self.timeout, *self._args, **self._kwargs)
+        self.pid = self.proc.pid
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type:
+            self.exception_occurred = True
+            # Forcefully kill the process group if any exception occurred, in particular,
+            # - KeyboardInterrupt (user pressed Ctrl+C in terminal)
+            # - any other medperf exception like OOM or bug
+            # - pexpect.TIMEOUT
+            logging.info(f'Killing ancestor processes because of exception: {exc_val=}')
+            self.killpg()
+
+        self.proc.close()
+        self.proc.wait()
+        # Return False to propagate exceptions, if any
+        return False

--- a/cli/requirements.txt
+++ b/cli/requirements.txt
@@ -21,3 +21,4 @@ schema==0.7.5
 setuptools<=66.1.1
 email-validator==2.0.0
 auth0-python==4.3.0
+GitPython==3.1.41


### PR DESCRIPTION
While reading output from spawned `mlcube` process, stop&display not only when a full line (ending with \n) is found, but when a line update (ending with \r) is got.