### PR TITLE
Modality change, fixed 250 epochs, and seeded splits logic

### DIFF
--- a/examples/fl_post/fl/mlcube/workspace/training_config.yaml
+++ b/examples/fl_post/fl/mlcube/workspace/training_config.yaml
@@ -29,7 +29,7 @@ aggregator :
           admin_settable: True
           min: -1.0        # inverts train_comleted, so this would be a way to have checkpoint_weighting = train_completed * data_size (as opposed to data_size / train_completed)
           max: 1.0 # leaves completion rates as is
-          value: 1.0
+          value: 0.0
 
       aggregated_model_validation:
         val_cutoff_time:

--- a/examples/fl_post/fl/mlcube/workspace/training_config.yaml
+++ b/examples/fl_post/fl/mlcube/workspace/training_config.yaml
@@ -5,7 +5,7 @@ aggregator :
     init_state_path : save/fl_post_two_init.pbuf
     best_state_path : save/fl_post_two_best.pbuf
     last_state_path : save/fl_post_two_last.pbuf
-    rounds_to_train : &rounds_to_train 2
+    rounds_to_train : &rounds_to_train 40
     admins_endpoints_mapping:
       testfladmin@example.com:
         - GetExperimentStatus
@@ -19,12 +19,12 @@ aggregator :
           admin_settable: True
           min: 10    # 10 seconds
           max: 86400 # one day
-          value: 86400   # one day
+          value: 20   # one day
         val_cutoff_time:
           admin_settable: True
           min: 10    # 10 seconds
           max: 86400 # one day
-          value: 86400   # one day
+          value: 20   # one day
         train_completion_dampener: # train_completed -> (train_completed)**(train_completion_dampener)   NOTE: Value close to zero zero shifts non 0.0 completion rates much closer to 1.0
           admin_settable: True
           min: -1.0        # inverts train_comleted, so this would be a way to have checkpoint_weighting = train_completed * data_size (as opposed to data_size / train_completed)
@@ -36,7 +36,7 @@ aggregator :
           admin_settable: True
           min: 10    # 10 seconds
           max: 86400 # one day
-          value: 86400   # one day
+          value: 20   # one day
 
 
 collaborator :

--- a/examples/fl_post/fl/project/nnunet_data_setup.py
+++ b/examples/fl_post/fl/project/nnunet_data_setup.py
@@ -311,7 +311,7 @@ def setup_fl_data(postopp_pardir,
     init_model_info_path(str)       : Path to the initial model info (pkl) file
     cuda_device(str)                : Device to perform training ('cpu' or 'cuda')
     overwrite_nnunet_datadirs(bool) : Allows for overwriting past instances of NNUnet data directories using the task numbers from first_three_digit_task_num to that plus one less than number of insitutions.
-    split_seed (int)                : Base seed for seeds used for the random number generator within the split logic
+    split_seed (int)                : Base seed for seeds used for the random number generators within the split logic
     plans_path(str)                 : Path to the training plans (pkl)
     percent_train(float)            : What percentage of timestamped subjects to attempt dedicate to train versus val. Will be only approximately acheived in general since
                                       all timestamps associated with the same subject need to land exclusively in either train or val.

--- a/examples/fl_post/fl/project/nnunet_data_setup.py
+++ b/examples/fl_post/fl/project/nnunet_data_setup.py
@@ -311,7 +311,7 @@ def setup_fl_data(postopp_pardir,
     init_model_info_path(str)       : Path to the initial model info (pkl) file
     cuda_device(str)                : Device to perform training ('cpu' or 'cuda')
     overwrite_nnunet_datadirs(bool) : Allows for overwriting past instances of NNUnet data directories using the task numbers from first_three_digit_task_num to that plus one less than number of insitutions.
-    split_seed (int)                : Seed used for the random number generator used within the split logic
+    split_seed (int)                : Base seed for seeds used for the random number generator within the split logic
     plans_path(str)                 : Path to the training plans (pkl)
     percent_train(float)            : What percentage of timestamped subjects to attempt dedicate to train versus val. Will be only approximately acheived in general since
                                       all timestamps associated with the same subject need to land exclusively in either train or val.

--- a/examples/fl_post/fl/project/nnunet_data_setup.py
+++ b/examples/fl_post/fl/project/nnunet_data_setup.py
@@ -14,8 +14,8 @@ from nnunet_model_setup import trim_data_and_setup_model
 
 num_to_modality = {'_0000': '_brain_t1n.nii.gz',
                    '_0001': '_brain_t2w.nii.gz',
-                   '_0002': '_brain_t1c.nii.gz',
-                   '_0003': '_brain_t2f.nii.gz'}
+                   '_0002': '_brain_t2f.nii.gz',
+                   '_0003': '_brain_t1c.nii.gz'}
 
 def get_subdirs(parent_directory):
     subjects = os.listdir(parent_directory)

--- a/examples/fl_post/fl/project/nnunet_data_setup.py
+++ b/examples/fl_post/fl/project/nnunet_data_setup.py
@@ -115,14 +115,16 @@ def doublecheck_postopp_pardir(postopp_pardir, verbose=False):
         raise ValueError(f"'labels' must be a subdirectory of postopp_src_pardir:{postopp_pardir}, but it is not.")
     
 
-def split_by_subject(subject_to_timestamps, percent_train, verbose=False):
+def split_by_subject(subject_to_timestamps, percent_train, split_seed, verbose=False):
     """
     NOTE: An attempt is made to put percent_train of the total subjects into train (as opposed to val) regardless of how many timestamps there are for each subject. 
      No subject is allowed to have samples in both train and val.
     """
 
     subjects = list(subject_to_timestamps.keys())
-    np.random.shuffle(subjects)
+    # create a random number generator with our seed
+    rng = np.random.default_rng(split_seed)
+    rng.shuffle(subjects)
 
     train_cutoff = int(len(subjects) * percent_train)
 
@@ -132,7 +134,7 @@ def split_by_subject(subject_to_timestamps, percent_train, verbose=False):
     return train_subject_to_timestamps, val_subject_to_timestamps
 
 
-def split_by_timed_subjects(subject_to_timestamps, percent_train, random_tries=30, verbose=False):
+def split_by_timed_subjects(subject_to_timestamps, percent_train, random_tries=30, split_seed, verbose=False):
     """
     NOTE: An attempt is made to put percent_train of the subject timestamp combinations into train (as opposed to val) regardless of what that does to the subject ratios. 
     No subject is allowed to have samples in both train and val.
@@ -143,9 +145,11 @@ def split_by_timed_subjects(subject_to_timestamps, percent_train, random_tries=3
             sub_total += subject_counts[subject]
         return sub_total/grand_total
 
-    def shuffle_and_cut(subject_counts, grand_total, percent_train, verbose=False):
+    def shuffle_and_cut(subject_counts, grand_total, percent_train, seed, verbose=False):
         subjects = list(subject_counts.keys())
-        np.random.shuffle(subjects)
+        # create a random number generator with our seed
+        rng = np.random.default_rng(seed)     
+        rng.shuffle(subjects)
         for idx in range(2,len(subjects)+1):
             train_subjects = subjects[:idx-1]
             val_subjects = subjects[idx-1:]
@@ -172,8 +176,9 @@ def split_by_timed_subjects(subject_to_timestamps, percent_train, random_tries=3
     best_percent_train = percent_train_for_split(train_subjects=best_train_subjects, grand_total=grand_total)
 
     # random shuffle <random_tries> times in order to find the closest we can get to honoring the percent_train requirement (train and val both need to be non-empty)
-    for _ in range(random_tries):
-        train_subjects, val_subjects, percent_train_estimate = shuffle_and_cut(subject_counts=subject_counts, grand_total=grand_total, percent_train=percent_train, verbose=verbose)
+    for _try in range(random_tries):
+        seed = split_seed + _try
+        train_subjects, val_subjects, percent_train_estimate = shuffle_and_cut(subject_counts=subject_counts, grand_total=grand_total, percent_train=percent_train, seed=seed, verbose=verbose)
         if abs(percent_train_estimate - percent_train) < abs(best_percent_train - percent_train):
             best_train_subjects = train_subjects
             best_val_subjects = val_subjects
@@ -185,16 +190,16 @@ def split_by_timed_subjects(subject_to_timestamps, percent_train, random_tries=3
     return train_subject_to_timestamps, val_subject_to_timestamps
   
 
-def write_splits_file(subject_to_timestamps, percent_train, split_logic, fold, task, splits_fname='splits_final.pkl', verbose=False):
+def write_splits_file(subject_to_timestamps, percent_train, split_logic, split_seed, fold, task, splits_fname='splits_final.pkl', verbose=False):
     # double check we are in the right folder to modify the splits file
     splits_fpath = os.path.join(os.environ['nnUNet_preprocessed'], f'{task}', splits_fname)
     POSTOPP_splits_fpath = os.path.join(os.environ['nnUNet_preprocessed'], f'{task}', 'POSTOPP_BACKUP_' + splits_fname)
 
     # now split
     if split_logic == 'by_subject':
-        train_subject_to_timestamps, val_subject_to_timestamps = split_by_subject(subject_to_timestamps=subject_to_timestamps, percent_train=percent_train, verbose=verbose)
+        train_subject_to_timestamps, val_subject_to_timestamps = split_by_subject(subject_to_timestamps=subject_to_timestamps, percent_train=percent_train, split_seed=split_seed, verbose=verbose)
     elif split_logic == 'by_subject_time_pair':
-        train_subject_to_timestamps, val_subject_to_timestamps = split_by_timed_subjects(subject_to_timestamps=subject_to_timestamps, percent_train=percent_train, verbose=verbose)    
+        train_subject_to_timestamps, val_subject_to_timestamps = split_by_timed_subjects(subject_to_timestamps=subject_to_timestamps, percent_train=percent_train, split_seed=split_seed, verbose=verbose)    
     else:
         raise ValueError(f"Split logic of 'by_subject' and 'by_subject_time_pair' are the only ones supported, whereas a split_logic value of {split_logic} was provided.")
 
@@ -235,6 +240,7 @@ def setup_fl_data(postopp_pardir,
                       init_model_info_path, 
                       cuda_device,
                       overwrite_nnunet_datadirs,
+                      split_seed=7777777,
                       plans_path=None, 
                       verbose=False):
     """
@@ -297,10 +303,6 @@ def setup_fl_data(postopp_pardir,
 
     three_digit_task_num(str): Should start with '5'.
     task_name(str)                 : Any string task name.
-    percent_train(float)           : what percent of data is put into the training data split (rest to val)
-    split_logic(str)               : Determines how train/val split is performed
-    timestamp_selection(str)       : Indicates how to determine the timestamp to pick
-                                   for each subject ID at the source: 'latest', 'earliest', and 'all' are the only ones supported so far
     network(str)                    : Which network is being used for NNUnet
     network_trainer(str)            : Which network trainer class is being used for NNUnet
     local_plans_identifier(str)     : Used in the plans file name for a collaborator that will be performing local training to produce an initial model
@@ -309,6 +311,7 @@ def setup_fl_data(postopp_pardir,
     init_model_info_path(str)       : Path to the initial model info (pkl) file
     cuda_device(str)                : Device to perform training ('cpu' or 'cuda')
     overwrite_nnunet_datadirs(bool) : Allows for overwriting past instances of NNUnet data directories using the task numbers from first_three_digit_task_num to that plus one less than number of insitutions.
+    split_seed (int)                : Seed used for the random number generator used within the split logic
     plans_path(str)                 : Path to the training plans (pkl)
     percent_train(float)            : What percentage of timestamped subjects to attempt dedicate to train versus val. Will be only approximately acheived in general since
                                       all timestamps associated with the same subject need to land exclusively in either train or val.
@@ -363,7 +366,8 @@ def setup_fl_data(postopp_pardir,
     # Now compute our own stratified splits file, keeping all timestampts for a given subject exclusively in either train or val
     write_splits_file(subject_to_timestamps=subject_to_timestamps, 
                           percent_train=percent_train, 
-                          split_logic=split_logic, 
+                          split_logic=split_logic,
+                          split_seed=split_seed, 
                           fold=fold, 
                           task=task, 
                           verbose=verbose)
@@ -415,3 +419,4 @@ def setup_fl_data(postopp_pardir,
         print(f"\n###   ###   ###   ###   ###   ###   ###\n")
     
     return col_paths
+    

--- a/examples/fl_post/fl/project/nnunet_data_setup.py
+++ b/examples/fl_post/fl/project/nnunet_data_setup.py
@@ -134,7 +134,7 @@ def split_by_subject(subject_to_timestamps, percent_train, split_seed, verbose=F
     return train_subject_to_timestamps, val_subject_to_timestamps
 
 
-def split_by_timed_subjects(subject_to_timestamps, percent_train, random_tries=30, split_seed, verbose=False):
+def split_by_timed_subjects(subject_to_timestamps, percent_train, split_seed, random_tries=30, verbose=False):
     """
     NOTE: An attempt is made to put percent_train of the subject timestamp combinations into train (as opposed to val) regardless of what that does to the subject ratios. 
     No subject is allowed to have samples in both train and val.
@@ -419,4 +419,3 @@ def setup_fl_data(postopp_pardir,
         print(f"\n###   ###   ###   ###   ###   ###   ###\n")
     
     return col_paths
-    

--- a/examples/fl_post/fl/project/nnunet_setup.py
+++ b/examples/fl_post/fl/project/nnunet_setup.py
@@ -19,7 +19,8 @@ def main(postopp_pardir,
          three_digit_task_num,  
          task_name, 
          percent_train=0.8, 
-         split_logic='by_subject_time_pair', 
+         split_logic='by_subject_time_pair',
+         split_seed=7777777, 
          network='3d_fullres', 
          network_trainer='nnUNetTrainerV2', 
          fold='0',
@@ -100,6 +101,7 @@ def main(postopp_pardir,
     percent_train(float)            : The percentage of samples to split into the train portion for the fold specified below (NNUnet makes its own folds but we overwrite
                                       all with None except the fold indicated below and put in our own split instead determined by a hard coded split logic default)
     split_logic(str)                : Determines how the percent_train is computed. Choices are: 'by_subject' and 'by_subject_time_pair' (see inner function docstring)
+    split_seed(int)                 : base rng seed used in split logic
     network(str)                    : NNUnet network to be used
     network_trainer(str)            : NNUnet network trainer to be used
     fold(str)                       : Fold to train on, can be a sting indicating an int, or can be 'all'
@@ -132,6 +134,7 @@ def main(postopp_pardir,
                              task_name=task_name,
                              percent_train=percent_train,
                              split_logic=split_logic,
+                             split_seed=split_seed,
                              fold=fold, 
                              timestamp_selection=timestamp_selection, 
                              network=network, 
@@ -187,6 +190,11 @@ if __name__ == '__main__':
             type=str,
             default='by_subject_time_pair',
             help="Determines how the percent_train is computed. Choices are: 'by_subject' and 'by_subject_time_pair' (see inner function docstring)")
+        argparser.add_argument(
+          '--split_seed',
+            type=int,
+            default=7777777,
+            help="base rng seed used in split logic") 
         argparser.add_argument(
           '--network',
             type=str,

--- a/examples/fl_post/fl/project/src/nnunet_v1.py
+++ b/examples/fl_post/fl/project/src/nnunet_v1.py
@@ -256,11 +256,10 @@ def train_nnunet(actual_max_num_epochs,
     trainer.max_num_epochs = fl_round + 1
     trainer.epoch = fl_round
 
-    # infer total data size and batch size in order to get how many batches to apply so that over many epochs, each data
-    # point is expected to be seen epochs number of times
-
-    num_val_batches_per_epoch = int(np.ceil(len(trainer.dataset_val)/trainer.batch_size))
-    num_train_batches_per_epoch = int(np.ceil(len(trainer.dataset_tr)/trainer.batch_size))
+    # STAYing WITH NNUNET CONVENTION OF 50 AND 250 VAL AND TRAIN BATCHES RESPECTIVELY
+    # Note: This convention makes sense in combination with a train_completion_dampener of 0.0
+    num_val_batches_per_epoch = 50 
+    num_train_batches_per_epoch = 250 
 
     # the nnunet trainer attributes have a different naming convention than I am using
     trainer.num_batches_per_epoch = num_train_batches_per_epoch


### PR DESCRIPTION
Modality is now fixed for the new initial model
Val and training batch counts are set at 50 and 250 as is done in NNUnet (with timouts still in place)
Train_completion dampener is set to 0.0 in the trianing_config I provide here (can bring over other plan of course but set this the same if so).
Splits logic is seeded to be reproducible

Splits logic tested independently with different seeds to see difference and reproducibility
