### PR TITLE
using list sorting for more determinism during os.listdir for split determination 

### DIFF
--- a/examples/fl_post/fl/project/nnunet_data_setup.py
+++ b/examples/fl_post/fl/project/nnunet_data_setup.py
@@ -20,7 +20,7 @@ num_to_modality = {'_0000': '_brain_t1n.nii.gz',
 def get_subdirs(parent_directory):
     subjects = os.listdir(parent_directory)
     subjects = [p for p in subjects if os.path.isdir(os.path.join(parent_directory, p)) and not p.startswith(".")]
-    return subjects
+    return sorted(subjects)
 
 
 def subject_time_to_mask_path(pardir, subject, timestamp):
@@ -73,7 +73,7 @@ def symlink_one_subject(postopp_subject_dir, postopp_data_dirpath, postopp_label
     if verbose:
         print(f"\n#######\nsymlinking subject: {postopp_subject_dir}\n########\nPostopp_data_dirpath: {postopp_data_dirpath}\n\n\n\n")
     postopp_subject_dirpath = os.path.join(postopp_data_dirpath, postopp_subject_dir)
-    all_timestamps = sorted(list(get_subdirs(postopp_subject_dirpath)))
+    all_timestamps = get_subdirs(postopp_subject_dirpath)
     if timestamp_selection == 'latest':
         timestamps = all_timestamps[-1:]
     elif timestamp_selection == 'earliest':
@@ -331,7 +331,7 @@ def setup_fl_data(postopp_pardir,
     postopp_data_dirpath = os.path.join(postopp_pardir, 'data')
     postopp_labels_dirpath = os.path.join(postopp_pardir, 'labels')
 
-    all_subjects = list(get_subdirs(postopp_data_dirpath))
+    all_subjects = get_subdirs(postopp_data_dirpath)
     
     # Track the subjects and timestamps for each shard
     subject_to_timestamps = {}


### PR DESCRIPTION
Removed some redundant list casting and also now sorting when using listdir for both subject subdirectories and timestamp subdirectories